### PR TITLE
Fix issue with agent temp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ temp
 *.map
 baseline-analysis-task/index.js
 delivery-analysis-task/index.js
-common/utils.js
+kiuwan-common/utils.js
 .taskkey
 KiuwanLocalANalyzer/**
 baseline-analysis-task/ps_modules

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ delivery-analysis-task/ps_modules
 baseline-analysis-task/node_modules
 delivery-analysis-task/node_modules
 *.zip
+*.txt
+endpoin-definition.json
+sample.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ temp
 *.map
 baseline-analysis-task/index.js
 delivery-analysis-task/index.js
+common/utils.js
 .taskkey
 KiuwanLocalANalyzer/**
 baseline-analysis-task/ps_modules
@@ -20,4 +21,5 @@ delivery-analysis-task/node_modules
 *.txt
 endpoin-definition.json
 sample.json
-
+_temp
+_tools

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ baseline-analysis-task/ps_modules
 delivery-analysis-task/ps_modules
 baseline-analysis-task/node_modules
 delivery-analysis-task/node_modules
+*.zip

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,7 @@
                 // "KIUWAN_HOME": "",
                 "INPUT_ANALYSISLABEL": "My label",
                 "INPUT_SKIPCLONES": "true",
+                "INPUT_SKIPARCH": "true",
                 "INPUT_ANALYSISSCOPE": "completeDelivery",
                 "INPUT_CRSTATUS": "resolved",
                 "INPUT_ENCODING": "UTF-8",
@@ -28,9 +29,10 @@
                 "SYSTEM_TEAMPROJECT": "My project",
                 "BUILD_SOURCESDIRECTORY": "${workspaceFolder}\\temp\\MyProjectCode",
                 "BUILD_SOURCEBRANCHNAME": "Development Branch",
-                "AGENT_NAME": "Private Agent",
+                "AGENT_NAME": "Any Agent",
                 "AGENT_HOMEDIRECTORY": "${workspaceFolder}",
-                "AGENT_TEMPDIRECTORY": "${workspaceFolder}\\temp"
+                "AGENT_TEMPDIRECTORY": "${workspaceFolder}\\temp",
+                "KIUWAN_HOME": ""
             },
             "sourceMaps": true,
             "outFiles": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,8 @@
                 "INPUT_TIMEOUT": "60",
                 "INPUT_BDANALYSIS": "false",
                 "INPUT_DBTECHNOLOGY": "None",
+                "INPUT_PROJECTNAMESELECTOR": "default",
+                "INPUT_KIUWANCONNECTION": "Kiuwan Connection",
                 "BUILD_BUILDNUMBER": "25",
                 "KIUWANUSER": "jellyfish@kiuwan.com",
                 "KIUWANPASSWD": "J4v13rS4l4d0",
@@ -31,7 +33,6 @@
                 "BUILD_SOURCEBRANCHNAME": "Development Branch",
                 "AGENT_NAME": "Any Agent",
                 "AGENT_HOMEDIRECTORY": "${workspaceFolder}",
-                "AGENT_TEMPDIRECTORY": "${workspaceFolder}\\temp",
                 "KIUWAN_HOME": ""
             },
             "sourceMaps": true,

--- a/baseline-analysis-task/index.ts
+++ b/baseline-analysis-task/index.ts
@@ -47,11 +47,39 @@ async function run() {
             technologies += dbtechnology;
         }
 
+        // Get the Kiuwan connection service authorization
+        let kiuwanConnection = tl.getInput("kiuwanConnection", true);
+        let kiuwanEndpointAuth = tl.getEndpointAuthorization(kiuwanConnection, true);
+        // Get user and password from variables defined in the build, otherwise get them from
+        // the Kiuwan service endpoint authorization
+        let kiuwanUser = tl.getVariable('KiuwanUser');
+        if (kiuwanUser === undefined || kiuwanUser === "") {
+            kiuwanUser = kiuwanEndpointAuth.parameters["username"];
+        }
+        let kiuwanPasswd = tl.getVariable('KiuwanPasswd');
+        if (kiuwanPasswd === undefined || kiuwanPasswd === "") {
+            kiuwanPasswd = kiuwanEndpointAuth.parameters["password"];
+        }
+
         // Get other relevant Variables from the task
         let buildNumber = tl.getVariable('Build.BuildNumber');
-        let kiuwanUser = tl.getVariable('KiuwanUser');
-        let kiuwanPasswd = tl.getVariable('KiuwanPasswd');
-        let projectName = tl.getVariable('System.TeamProject');
+        // Now the project name may come from different sources
+        // the System.TeamProject variable, an existing Kiuwan app name or a new one
+        let projectSelector = tl.getInput('projectnameselector');
+        let projectName = '';
+        if (projectSelector === 'default') {
+            projectName = tl.getVariable('System.TeamProject');
+            console.log(`Kiuwan application from System.TeamProject: ${projectName}`);
+        }
+        if (projectSelector === 'kiuwanapp') {
+            projectName = tl.getInput('kiuwanappname');
+            console.log(`Kiuwan application from Kiuwan app list: ${projectName}`);
+        }
+        if (projectSelector === 'appname') {
+            projectName = tl.getInput('customappname');
+            console.log(`Kiuwan application from user input: ${projectName}`);
+        }
+        
         let sourceDirectory = tl.getVariable('Build.SourcesDirectory');
         let agentName = tl.getVariable('Agent.Name');
 

--- a/baseline-analysis-task/index.ts
+++ b/baseline-analysis-task/index.ts
@@ -24,11 +24,11 @@ async function run() {
         if (skipclones) {
             ignoreclause = "ignore=clones";
             if (skiparch) {
-                ignoreclause += ",architecture";
+                ignoreclause += ",architecture,insights";
             }
         }
         else if (skiparch) {
-            ignoreclause = "ignore=architecture";
+            ignoreclause = "ignore=architecture,insights";
         }
 
         let encoding = tl.getInput('encoding');
@@ -54,52 +54,40 @@ async function run() {
         let projectName = tl.getVariable('System.TeamProject');
         let sourceDirectory = tl.getVariable('Build.SourcesDirectory');
         let agentName = tl.getVariable('Agent.Name');
-        let isHostedAgent = agentName.startsWith('Hosted');
 
         let agentHomeDir = tl.getVariable('Agent.HomeDirectory');
 
         let kla = 'Not installed yet';
 
-        if (isHostedAgent) {
-            // Download and install the agent in the Working directory
-            console.log(`Hosted Agent: ${osPlat}`)
-            let installPath: string = await downloadInstallKla(false, osPlat);
+        // We treat al agents equal now:
+        // Check if the KLA is already installed, either because the KIUWAN_HOME variable
+        // is set or because it was installed by a previous task execution.
+        var kiuwanHome: string;
+        kiuwanHome = tl.getVariable('KIUWAN_HOME');
 
-            console.log('KLA Installed in: ' + installPath);
+        console.log(`Running on Agent: ${agentName} (${osPlat})`);
 
-            // build the KLA command for the corresponding OS
-            kla = await buildKlaCommand(installPath, osPlat, true);
-
-            // Add the kla directory to the exclude patters so it is not analyzed
-            excludePatterns += ',KiuwanLocalAnalyzer/**';
+        if (kiuwanHome !== undefined && kiuwanHome !== "") {
+            let klaDefaultPath = 'KiuwanLocalAnalyzer';
+            let hasDefaultPath = kiuwanHome.endsWith(klaDefaultPath); console.log(`KIUWAN_HOME env variable defined: ${kiuwanHome}`);
+            kiuwanHome = hasDefaultPath ? kiuwanHome.substring(0, kiuwanHome.lastIndexOf(klaDefaultPath)) : kiuwanHome;
+            kla = await buildKlaCommand(kiuwanHome, osPlat);
         }
         else {
-            // For private agents:
-            // Check if the KLA is already installed, either because the KIUWAN_HOME variable
-            // is set or because it was installed by a previous task execution.
-            var kiuwanHome: string;
-            kiuwanHome = tl.getVariable('KIUWAN_HOME');
-        
-            if ( kiuwanHome !== undefined && kiuwanHome !== "") {
-                let klaDefaultPath = 'KiuwanLocalAnalyzer';
-                let hasDefaultPath = kiuwanHome.endsWith(klaDefaultPath);                console.log(`KIUWAN_HOME env variable defined: ${kiuwanHome}`);
-                kiuwanHome = hasDefaultPath ? kiuwanHome.substring(0,kiuwanHome.lastIndexOf(klaDefaultPath)) : kiuwanHome;
-                kla = await buildKlaCommand(kiuwanHome, osPlat);
-            }
-            else {
-                // Check if it is installed in the Agent home from a previosu task run
-                console.log(`Checking for KLA previously installed in the agent home: ${agentHomeDir}`);
-                kla = await buildKlaCommand(agentHomeDir, osPlat);
-            }
+            // Check if it is installed in the Agent home from a previosu task run
+            console.log(`Checking for KLA previously installed in the agent home: ${agentHomeDir}`);
+            kla = await buildKlaCommand(agentHomeDir, osPlat);
+        }
 
-            if ( kla.length === 0) {
-                // KLA not installed. So we install it in the Agent.HomeDirectory
-                console.log("No KLA installation found...");
-                console.log(`Downloading and installing KLA in the agent home: ${agentHomeDir}`);
-                let klaInstallPath = await downloadInstallKla(true, osPlat);
+        if (kla.length === 0) {
+            // KLA not installed. So we install it in the Agent.HomeDirectory
+            console.log("No KLA installation found...");
+            console.log(`Downloading and installing KLA in the agent home: ${agentHomeDir}`);
+            let klaInstallPath = await downloadInstallKla(osPlat);
 
-                kla = await buildKlaCommand(klaInstallPath, osPlat, true);
-            }
+            console.log(`Kiuwan Local Analyzer installed at: ${klaInstallPath}!`);
+
+            kla = await buildKlaCommand(klaInstallPath, osPlat, true);
         }
 
         let klaArgs: string =
@@ -118,12 +106,11 @@ async function run() {
             `timeout=${timeout} ` +
             `${ignoreclause}`;
 
-        console.log('Kiuwan Local Analyzer installed! ');
         console.log('Running Kiuwan analysis');
 
-        let kiuwanRetCode: Number = await runKiuwanLocalAnalyzer(kla, klaArgs, 'baseline');
+        let kiuwanRetCode: Number = await runKiuwanLocalAnalyzer(kla, klaArgs);
 
-        switch ( kiuwanRetCode ) {
+        switch (kiuwanRetCode) {
             case 1: {
                 console.error(`KLA Error ${kiuwanRetCode}: Analyzer execution error .Run-time execution error (out of memory, etc.). Review log files to find exact cause.`);
                 break;
@@ -234,50 +221,44 @@ async function buildKlaCommand(klaPath: string, platform: string, chmod?: boolea
     return command;
 }
 
-async function downloadInstallKla(isPrivate: boolean, platform: string) {
+async function downloadInstallKla(platform: string) {
     // The downloadTool ALWAYS downloads to the AgentTempDirectory.
-    // For private agents, we set the AgentTemDirectory variable to AgentHome directory 
+    // We set the AgentTemDirectory variable to AgentHome directory 
     // to install it there (in subsequent task runs we check for it there)
-    if ( isPrivate ) {
-        tl.setVariable('Agent.TempDirectory', agentHomeDir);
-    }
+    tl.setVariable('Agent.TempDirectory', agentHomeDir);
 
     let downloadPath: string = await ttl.downloadTool('https://www.kiuwan.com/pub/analyzer/KiuwanLocalAnalyzer.zip', 'KiuwanLocalAnalyzer.zip');
 
     let extPath: string = await ttl.extractZip(downloadPath);
 
     // the extractZip tool ALWAYS extracts to a uuidv4 created directory.
-    // for pricvate agents we want to move the KLA directory to the Agent.HomeDirectory
+    // we want to move the KLA directory to the Agent.HomeDirectory
     let origPath: string;
     let destPath: string;
-    if ( isPrivate ) {
-        if (platform === 'linux' || platform === 'darwin') {
-            origPath = `${extPath}/KiuwanLocalAnalyzer`
-            destPath = path.normalize(`${extPath}/..`);
-            let ret = await tl.exec('mv',`${origPath} ${destPath}`);
+    if (platform === 'linux' || platform === 'darwin') {
+        origPath = `${extPath}/KiuwanLocalAnalyzer`
+        destPath = path.normalize(`${extPath}/..`);
+        let ret = await tl.exec('mv', `${origPath} ${destPath}`);
+        if (ret != 0) {
             console.error(`Error moving KLA installation. mv returned: ${ret}`);
-        } 
-        else {
-            origPath = `${extPath}\\KiuwanLocalAnalyzer`
-            destPath = path.normalize(`${extPath}\\..`);            
-            let ret = await tl.exec('powershell',`-command "Move-Item -Path '${origPath}' -Destination '${destPath}'"`);
+        }
+    }
+    else {
+        origPath = `${extPath}\\KiuwanLocalAnalyzer`
+        destPath = path.normalize(`${extPath}\\..`);
+        let ret = await tl.exec('powershell', `-command "Move-Item -Path '${origPath}' -Destination '${destPath}'"`);
+        if (ret != 0) {
             console.error(`Error moving KLA installation. Move-Item returned: ${ret}`);
         }
-
-        extPath = destPath;
     }
 
-    return extPath;
+    return destPath;
 }
 
-async function runKiuwanLocalAnalyzer(command: string, args: string, mode: string) {
+async function runKiuwanLocalAnalyzer(command: string, args: string) {
     let exitCode: Number = 0;
 
     // Run KLA with ToolRunner
-    if (mode == 'delivery') {
-        args +=" -as completeDelivery";
-    }
-
     let kiuwan = tl.tool(command).line(args);
 
     let options = <trm.IExecOptions>{

--- a/baseline-analysis-task/index.ts
+++ b/baseline-analysis-task/index.ts
@@ -97,7 +97,8 @@ async function run() {
 
         if (kiuwanHome !== undefined && kiuwanHome !== "") {
             let klaDefaultPath = 'KiuwanLocalAnalyzer';
-            let hasDefaultPath = kiuwanHome.endsWith(klaDefaultPath); console.log(`KIUWAN_HOME env variable defined: ${kiuwanHome}`);
+            let hasDefaultPath = kiuwanHome.endsWith(klaDefaultPath); 
+            console.log(`KIUWAN_HOME env variable defined: ${kiuwanHome}`);
             kiuwanHome = hasDefaultPath ? kiuwanHome.substring(0, kiuwanHome.lastIndexOf(klaDefaultPath)) : kiuwanHome;
             kla = await buildKlaCommand(kiuwanHome, osPlat);
         }
@@ -183,7 +184,7 @@ async function run() {
                 console.error(`KLA Error ${kiuwanRetCode}: Error checking license. Error while getting or checking Kiuwan license	Contact Kiuwan Technical Support`);
                 break;
             }
-            case 20: {
+            case 22: {
                 console.error(`KLA Error ${kiuwanRetCode}: Access denied. Lack of permissions to access some Kiuwan entity (application analyses, deliveries, etc). Review log files to find exact cause and contact your Kiuwan administrator.`);
                 break;
             }
@@ -250,10 +251,8 @@ async function buildKlaCommand(klaPath: string, platform: string, chmod?: boolea
 }
 
 async function downloadInstallKla(platform: string) {
-    // The downloadTool ALWAYS downloads to the AgentTempDirectory.
-    // We set the AgentTemDirectory variable to AgentHome directory 
-    // to install it there (in subsequent task runs we check for it there)
-    tl.setVariable('Agent.TempDirectory', agentHomeDir);
+    let agentTempDir = tl.getVariable('Agent.TempDirectory');
+    console.log(`Agent Temp Dir: ${agentTempDir}`);
 
     let downloadPath: string = await ttl.downloadTool('https://www.kiuwan.com/pub/analyzer/KiuwanLocalAnalyzer.zip', 'KiuwanLocalAnalyzer.zip');
 
@@ -265,7 +264,7 @@ async function downloadInstallKla(platform: string) {
     let destPath: string;
     if (platform === 'linux' || platform === 'darwin') {
         origPath = `${extPath}/KiuwanLocalAnalyzer`
-        destPath = path.normalize(`${extPath}/..`);
+        destPath = path.normalize(`${agentHomeDir}`);
         let ret = await tl.exec('mv', `${origPath} ${destPath}`);
         if (ret != 0) {
             console.error(`Error moving KLA installation. mv returned: ${ret}`);
@@ -273,7 +272,7 @@ async function downloadInstallKla(platform: string) {
     }
     else {
         origPath = `${extPath}\\KiuwanLocalAnalyzer`
-        destPath = path.normalize(`${extPath}\\..`);
+        destPath = path.normalize(`${agentHomeDir}`);
         let ret = await tl.exec('powershell', `-command "Move-Item -Path '${origPath}' -Destination '${destPath}'"`);
         if (ret != 0) {
             console.error(`Error moving KLA installation. Move-Item returned: ${ret}`);

--- a/baseline-analysis-task/index.ts
+++ b/baseline-analysis-task/index.ts
@@ -1,16 +1,19 @@
-import path = require('path')
 import os = require('os');
 import tl = require('vsts-task-lib/task');
-import ttl = require('vsts-task-tool-lib/tool')
-import trm = require('vsts-task-lib/toolrunner');
-import { extractZip } from 'vsts-task-tool-lib/tool';
-import { _exist } from 'vsts-task-lib/internal';
-import { isPrimitive } from 'util';
+import { buildKlaCommand,setAgentTempDir,setAgentToolsDir,downloadInstallKla,runKiuwanLocalAnalyzer,checkKuwanRetCode } from 'kiuwan-common/utils';
 
 var osPlat: string = os.platform();
 var agentHomeDir = tl.getVariable('Agent.HomeDirectory');
+var agentTempDir = tl.getVariable('Agent.TempDirectory');
+if (!agentTempDir) {
+    agentTempDir = setAgentTempDir(agentHomeDir,osPlat);
+}
+var agentToolsDir = tl.getVariable('Agent.ToolsDirectory');
+if (!agentToolsDir) {
+    agentToolsDir = setAgentToolsDir(agentHomeDir,osPlat);
+}
 const toolName = 'KiuwanLocalAnalyzer';
-const toolVersion = '2.1.2';
+const toolVersion = '1.0.0';
 
 async function run() {
     try {
@@ -81,11 +84,9 @@ async function run() {
             projectName = tl.getInput('customappname');
             console.log(`Kiuwan application from user input: ${projectName}`);
         }
-        
+
         let sourceDirectory = tl.getVariable('Build.SourcesDirectory');
         let agentName = tl.getVariable('Agent.Name');
-
-        let agentHomeDir = tl.getVariable('Agent.HomeDirectory');
 
         let kla = 'Not installed yet';
 
@@ -99,26 +100,18 @@ async function run() {
 
         if (kiuwanHome !== undefined && kiuwanHome !== "") {
             let klaDefaultPath = 'KiuwanLocalAnalyzer';
-            let hasDefaultPath = kiuwanHome.endsWith(klaDefaultPath); 
+            let hasDefaultPath = kiuwanHome.endsWith(klaDefaultPath);
             console.log(`KIUWAN_HOME env variable defined: ${kiuwanHome}`);
             kiuwanHome = hasDefaultPath ? kiuwanHome.substring(0, kiuwanHome.lastIndexOf(klaDefaultPath)) : kiuwanHome;
             kla = await buildKlaCommand(kiuwanHome, osPlat);
         }
         else {
-            // Check if it is installed in the Agent home from a previosu task run
-            console.log(`Checking for KLA previously installed in the agent home: ${agentHomeDir}`);
-            kla = await buildKlaCommand(agentHomeDir, osPlat);
-        }
+            // Check if it is installed in the Agent tools directory from a previosu task run
+            // It will download and install it in the Agent Tools directory if not found
+            let klaInstallPath = await downloadInstallKla(toolName,toolVersion,osPlat);
 
-        if (kla.length === 0) {
-            // KLA not installed. So we install it in the Agent.HomeDirectory
-            console.log("No KLA installation found...");
-            console.log(`Downloading and installing KLA in the agent home: ${agentHomeDir}`);
-            let klaInstallPath = await downloadInstallKla(osPlat);
-
-            console.log(`Kiuwan Local Analyzer installed at: ${klaInstallPath}!`);
-
-            kla = await buildKlaCommand(klaInstallPath, osPlat, true);
+            // Get the appropriate kla command depending on the platform
+            kla = await buildKlaCommand(klaInstallPath, osPlat);
         }
 
         let klaArgs: string =
@@ -141,83 +134,7 @@ async function run() {
 
         let kiuwanRetCode: Number = await runKiuwanLocalAnalyzer(kla, klaArgs);
 
-        switch (kiuwanRetCode) {
-            case 1: {
-                console.error(`KLA Error ${kiuwanRetCode}: Analyzer execution error .Run-time execution error (out of memory, etc.). Review log files to find exact cause.`);
-                break;
-            }
-            case 10: {
-                console.error(`KLA Error ${kiuwanRetCode}: Audit overall result = FAIL. Audit associated to the analyzed application did not pass. See audit report for exact reasons of non compliance (checkpoints not passed, etc.)`);
-                break;
-            }
-            case 11: {
-                console.error(`KLA Error ${kiuwanRetCode}: Invalid analysis configuration. Some configuration parameter has a wrong value. Review log files to find exact cause`);
-                break;
-            }
-            case 12: {
-                console.error(`KLA Error ${kiuwanRetCode}: The downloaded model does not support any of the discovered languages. The model specified for the application does not contains rules for the technologies being analyzed. Select an appropriate model or modify the model to include those technologies not currently supported`);
-                break;
-            }
-            case 13: {
-                console.error(`KLA Error ${kiuwanRetCode}: Timeout waiting for analysis results. After finishing the local analysis, results were uploaded to Kiuwan site but the second phase (index calculation) timed out. A very common reason for this problem is when your account has reached the maximun number of analyzed locs per 24h. In this case, your analysis is enqueued and local analyzer times out. This does not mean that the analysis has failed. Indeed, the analysis is only enqueued and it will be processed as soon as the limit is over. In this situation you don't need to execute again the analysis, just wait, it will be run automatically.`);
-                break;
-            }
-            case 14: {
-                console.error(`KLA Error ${kiuwanRetCode}: Analysis finished with error in Kiuwan. Although local analysis finished successfully, there was some error during analysis processing in the cloud. Visit the log page associated to the analysis.`);
-                break;
-            }
-            case 15: {
-                console.error(`KLA Error ${kiuwanRetCode}: Timeout: killed the subprocess. Local analysis timed out. Increase timeout value to a higher value.`);
-                break;
-            }
-            case 16: {
-                console.error(`KLA Error ${kiuwanRetCode}: Account limits exceeded. Some limit in the Kiuwan account is reached (max number of account’s analysis is reached, etc.). Contact Kiuwan Technical Support if you have any question on your acccount’s limits.`);
-                break;
-            }
-            case 17: {
-                console.error(`KLA Error ${kiuwanRetCode}: Delivery analysis not permitted for current user. User does not have permission to run delivery analysis for the current application.	Check the user has “Execute deliveries” privilege on the application.`);
-                break;
-            }
-            case 18: {
-                console.error(`KLA Error ${kiuwanRetCode}: No analyzable extensions found. Kiuwan recognizes the technology of a source file by its extension. But source files to analyze do not match any of the recognized extensions.`);
-                break;
-            }
-            case 19: {
-                console.error(`KLA Error ${kiuwanRetCode}: Error checking license. Error while getting or checking Kiuwan license	Contact Kiuwan Technical Support`);
-                break;
-            }
-            case 22: {
-                console.error(`KLA Error ${kiuwanRetCode}: Access denied. Lack of permissions to access some Kiuwan entity (application analyses, deliveries, etc). Review log files to find exact cause and contact your Kiuwan administrator.`);
-                break;
-            }
-            case 23: {
-                console.error(`KLA Error ${kiuwanRetCode}: Bad Credentials. User-supplied credentials are not valid. Contact your Kiuwan administrator.`);
-                break;
-            }
-            case 24: {
-                console.error(`KLA Error ${kiuwanRetCode}: Application Not Found. The invoked action cannot be completed because the associated application does not exist. Review log files to find exact cause and contact your Kiuwan administrator.`);
-                break;
-            }
-            case 25: {
-                console.error(`KLA Error ${kiuwanRetCode}: Limit Exceeded for Calls to Kiuwan API. Limit of max Kiuwan API calls per hour has been exceeded.	Contact Kiuwan Technical Support if you have any question on your acccount’s limits.`);
-                break;
-            }
-            case 26: {
-                console.error(`KLA Error ${kiuwanRetCode}: Quota Limit Reached. Some limit in the Kiuwan account is reached (max number of account’s analysis is reached, etc.). Contact Kiuwan Technical Support if you have any question on your acccount’s limits.`);
-                break;
-            }
-            case 27: {
-                console.error(`KLA Error ${kiuwanRetCode}: Analysis Not Found. The invoked action cannot be completed because the associated analysis does not exist. Review log files to find exact cause. Contact Kiuwan Technical Support`);
-                break;
-            }
-            case 28: {
-                console.error(`KLA Error ${kiuwanRetCode}: Application already exists`);
-                break;
-            }
-            default: {
-                console.log(`KLA returned ${kiuwanRetCode} Analysis finished successfully!`);
-            }
-        }
+        checkKuwanRetCode(kiuwanRetCode);
 
         if (kiuwanRetCode !== 0) {
             tl.setResult(tl.TaskResult.Failed, 'Kiuwan analysis failed! See messages above.');
@@ -227,68 +144,6 @@ async function run() {
         tl.setResult(tl.TaskResult.Failed, err.message);
         console.error('Task failed: ' + err.message);
     }
-}
-
-async function buildKlaCommand(klaPath: string, platform: string, chmod?: boolean) {
-    let command: string;
-    let defaultKiuwanDir: string = 'KiuwanLocalAnalyzer';
-    let dirExist: boolean;
-
-    if (platform === 'linux' || platform === 'darwin') {
-        // Define the KLA command if install directory exisits
-        dirExist = _exist(`${klaPath}/${defaultKiuwanDir}`);
-        console.log(`${klaPath}/${defaultKiuwanDir}: ${dirExist}`);
-        command = dirExist ? `${klaPath}/${defaultKiuwanDir}/bin/agent.sh` : "";
-        if (chmod) {
-            let ret = await tl.exec('chmod', `+x ${klaPath}/${defaultKiuwanDir}/bin/agent.sh`);
-            console.error(`chmod retuned: ${ret}`);
-        }
-    }
-    else {
-        dirExist = _exist(`${klaPath}\\${defaultKiuwanDir}`);
-        command = dirExist ? `${klaPath}\\${defaultKiuwanDir}\\bin\\agent.cmd` : "";
-    }
-
-    return command;
-}
-
-async function downloadInstallKla(platform: string) {
-    let toolPath = ttl.findLocalTool(toolName, toolVersion);
-    if (!toolPath) {
-        let downloadPath: string = await ttl.downloadTool('https://www.kiuwan.com/pub/analyzer/KiuwanLocalAnalyzer.zip', 'KiuwanLocalAnalyzer.zip');
-
-        let extPath: string = await ttl.extractZip(downloadPath);
-        toolPath = await ttl.cacheDir(extPath, toolName, toolVersion);
-    }
-
-    return toolPath;
-}
-
-async function runKiuwanLocalAnalyzer(command: string, args: string) {
-    let exitCode: Number = 0;
-
-    // Run KLA with ToolRunner
-    let kiuwan = tl.tool(command).line(args);
-
-    let options = <trm.IExecOptions>{
-        cwd: '.',
-        env: process.env,
-        silent: false,
-        windowsVerbatimArguments: false,
-        failOnStdErr: false,
-        errStream: process.stdout,
-        outStream: process.stdout,
-        ignoreReturnCode: true
-    }
-
-    kiuwan.on('stdout', (data) => {
-        let output = data.toString().trim();
-        tl.debug(output);
-    })
-
-    exitCode = await kiuwan.exec(options);
-
-    return exitCode;
 }
 
 run();

--- a/baseline-analysis-task/task.json
+++ b/baseline-analysis-task/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 2
+        "Patch": 11
     },
     "visibility": [
         "Build",

--- a/baseline-analysis-task/task.json
+++ b/baseline-analysis-task/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 2,
-        "Patch": 3
+        "Patch": 6
     },
     "visibility": [
         "Build",

--- a/baseline-analysis-task/task.json
+++ b/baseline-analysis-task/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 2,
-        "Patch": 1
+        "Patch": 3
     },
     "visibility": [
         "Build",

--- a/baseline-analysis-task/task.json
+++ b/baseline-analysis-task/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 1
     },
     "visibility": [
         "Build",
@@ -43,7 +43,7 @@
             "type": "connectedService:Kiuwan",
             "label": "Kiuwan Service",
             "defaultValue": "",
-            "required": true,
+            "required": false,
             "helpMarkDown": "Kiuwan service connection"
         },
         {
@@ -53,7 +53,7 @@
             "defaultValue": "default",
             "required": true,
             "options": {
-                "default": "System.TeamProject",
+                "default": "$(System.TeamProject)",
                 "kiuwanapp": "Kiuwan application from list",
                 "appname": "Define a custom name"
             },

--- a/baseline-analysis-task/task.json
+++ b/baseline-analysis-task/task.json
@@ -8,8 +8,8 @@
     "author": "Javier Salado",
     "version": {
         "Major": 2,
-        "Minor": 1,
-        "Patch": 11
+        "Minor": 2,
+        "Patch": 0
     },
     "visibility": [
         "Build",
@@ -38,6 +38,44 @@
         }
     ],
     "inputs": [
+        {
+            "name": "kiuwanConnection",
+            "type": "connectedService:Kiuwan",
+            "label": "Kiuwan Service",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "Kiuwan service connection"
+        },
+        {
+            "name": "projectnameselector",
+            "type": "radio",
+            "label": "What do you want to use as Kiuwan application name?",
+            "defaultValue": "default",
+            "required": true,
+            "options": {
+                "default": "System.TeamProject",
+                "kiuwanapp": "Kiuwan application from list",
+                "appname": "Define a custom name"
+            },
+            "helpMarkDown": "You can use System.TeamProject variable, pick an aexisting application from a list or set a new application name."
+        },
+        {
+            "name": "kiuwanappname",
+            "type": "pickList",
+            "label": "Available Kiuwan applications",
+            "required": false,
+            "visibleRule": "projectnameselector = kiuwanapp",
+            "helpMarkDown": "Select an existing application in Kiuwan to associate results to."
+        },
+        {
+            "name": "customappname",
+            "type": "string",
+            "label": "Kiuwan application name",
+            "defaultValue": "",
+            "required": false,
+            "visibleRule": "projectnameselector = appname",
+            "helpMarkDown": "Custom application name in Kiuwan to associate results to. It will be cautomatically created if it doesn't exist in your account."
+        },
         {
             "name": "analysislabel",
             "type": "string",
@@ -133,6 +171,13 @@
                 "informix": "Informix stored procedures"
             },
             "helpMarkDown": "Please, select the type of stored procedures you use in your application. We support Oracle PL/SQL, Microsoft SQLServer TransactSQL, Sybase Transact and Informix stored procedures."
+        }
+    ],
+    "dataSourceBindings": [
+        {
+            "target": "kiuwanappname",
+            "endpointId": "$(kiuwanConnection)",
+            "dataSourceName": "ListApplications"
         }
     ],
     "execution": {

--- a/delivery-analysis-task/index.ts
+++ b/delivery-analysis-task/index.ts
@@ -1,14 +1,19 @@
-import path = require('path')
 import os = require('os');
 import tl = require('vsts-task-lib/task');
-import ttl = require('vsts-task-tool-lib/tool')
-import trm = require('vsts-task-lib/toolrunner');
-import { extractZip } from 'vsts-task-tool-lib/tool';
-import { _exist } from 'vsts-task-lib/internal';
-import { isPrimitive } from 'util';
+import { buildKlaCommand, setAgentTempDir, setAgentToolsDir, downloadInstallKla, runKiuwanLocalAnalyzer, checkKuwanRetCode } from 'kiuwan-common/utils';
 
 var osPlat: string = os.platform();
 var agentHomeDir = tl.getVariable('Agent.HomeDirectory');
+var agentTempDir = tl.getVariable('Agent.TempDirectory');
+if (!agentTempDir) {
+    agentTempDir = setAgentTempDir(agentHomeDir,osPlat);
+}
+var agentToolsDir = tl.getVariable('Agent.ToolsDirectory');
+if (!agentToolsDir) {
+    agentToolsDir = setAgentToolsDir(agentHomeDir,osPlat);
+}
+const toolName = 'KiuwanLocalAnalyzer';
+const toolVersion = '1.0.0';
 
 async function run() {
     try {
@@ -52,7 +57,7 @@ async function run() {
 
         // Get the Kiuwan connection service authorization
         let kiuwanConnection = tl.getInput("kiuwanConnection", true);
-        let kiuwanEndpointAuth = tl.getEndpointAuthorization(kiuwanConnection,true);
+        let kiuwanEndpointAuth = tl.getEndpointAuthorization(kiuwanConnection, true);
         // Get user and password from variables defined in the build, otherwise get them from
         // the Kiuwan service endpoint authorization
         let kiuwanUser = tl.getVariable('KiuwanUser');
@@ -84,11 +89,9 @@ async function run() {
             projectName = tl.getInput('customappname');
             console.log(`Kiuwan application from user input: ${projectName}`);
         }
-        
+
         let sourceDirectory = tl.getVariable('Build.SourcesDirectory');
         let agentName = tl.getVariable('Agent.Name');
-
-        let agentHomeDir = tl.getVariable('Agent.HomeDirectory');
 
         let kla = 'Not installed yet';
 
@@ -106,20 +109,12 @@ async function run() {
             kla = await buildKlaCommand(kiuwanHome, osPlat);
         }
         else {
-            // Check if it is installed in the Agent home from a previosu task run
-            console.log(`Checking for KLA previously installed in the agent home: ${agentHomeDir}`);
-            kla = await buildKlaCommand(agentHomeDir, osPlat);
-        }
+            // Check if it is installed in the Agent tools directory from a previosu task run
+            // It will download and install it in the Agent Tools directory if not found
+            let klaInstallPath = await downloadInstallKla(toolName,toolVersion,osPlat);
 
-        if (kla.length === 0) {
-            // KLA not installed. So we install it in the Agent.HomeDirectory
-            console.log("No KLA installation found...");
-            console.log(`Downloading and installing KLA in the agent home: ${agentHomeDir}`);
-            let klaInstallPath = await downloadInstallKla(osPlat);
-
-            console.log(`Kiuwan Local Analyzer installed at: ${klaInstallPath}!`);
-
-            kla = await buildKlaCommand(klaInstallPath, osPlat, true);
+            // Get the appropriate kla command depending on the platform
+            kla = await buildKlaCommand(klaInstallPath, osPlat);
         }
 
         let klaArgs: string =
@@ -145,83 +140,8 @@ async function run() {
 
         let kiuwanRetCode: Number = await runKiuwanLocalAnalyzer(kla, klaArgs);
 
-        switch (kiuwanRetCode) {
-            case 1: {
-                console.error(`KLA Error ${kiuwanRetCode}: Analyzer execution error .Run-time execution error (out of memory, etc.). Review log files to find exact cause.`);
-                break;
-            }
-            case 10: {
-                console.error(`KLA Error ${kiuwanRetCode}: Audit overall result = FAIL. Audit associated to the analyzed application did not pass. See audit report for exact reasons of non compliance (checkpoints not passed, etc.)`);
-                break;
-            }
-            case 11: {
-                console.error(`KLA Error ${kiuwanRetCode}: Invalid analysis configuration. Some configuration parameter has a wrong value. Review log files to find exact cause`);
-                break;
-            }
-            case 12: {
-                console.error(`KLA Error ${kiuwanRetCode}: The downloaded model does not support any of the discovered languages. The model specified for the application does not contains rules for the technologies being analyzed. Select an appropriate model or modify the model to include those technologies not currently supported`);
-                break;
-            }
-            case 13: {
-                console.error(`KLA Error ${kiuwanRetCode}: Timeout waiting for analysis results. After finishing the local analysis, results were uploaded to Kiuwan site but the second phase (index calculation) timed out. A very common reason for this problem is when your account has reached the maximun number of analyzed locs per 24h. In this case, your analysis is enqueued and local analyzer times out. This does not mean that the analysis has failed. Indeed, the analysis is only enqueued and it will be processed as soon as the limit is over. In this situation you don't need to execute again the analysis, just wait, it will be run automatically.`);
-                break;
-            }
-            case 14: {
-                console.error(`KLA Error ${kiuwanRetCode}: Analysis finished with error in Kiuwan. Although local analysis finished successfully, there was some error during analysis processing in the cloud. Visit the log page associated to the analysis.`);
-                break;
-            }
-            case 15: {
-                console.error(`KLA Error ${kiuwanRetCode}: Timeout: killed the subprocess. Local analysis timed out. Increase timeout value to a higher value.`);
-                break;
-            }
-            case 16: {
-                console.error(`KLA Error ${kiuwanRetCode}: Account limits exceeded. Some limit in the Kiuwan account is reached (max number of account’s analysis is reached, etc.). Contact Kiuwan Technical Support if you have any question on your acccount’s limits.`);
-                break;
-            }
-            case 17: {
-                console.error(`KLA Error ${kiuwanRetCode}: Delivery analysis not permitted for current user. User does not have permission to run delivery analysis for the current application.	Check the user has “Execute deliveries” privilege on the application.`);
-                break;
-            }
-            case 18: {
-                console.error(`KLA Error ${kiuwanRetCode}: No analyzable extensions found. Kiuwan recognizes the technology of a source file by its extension. But source files to analyze do not match any of the recognized extensions.`);
-                break;
-            }
-            case 19: {
-                console.error(`KLA Error ${kiuwanRetCode}: Error checking license. Error while getting or checking Kiuwan license	Contact Kiuwan Technical Support`);
-                break;
-            }
-            case 22: {
-                console.error(`KLA Error ${kiuwanRetCode}: Access denied. Lack of permissions to access some Kiuwan entity (application analyses, deliveries, etc). Review log files to find exact cause and contact your Kiuwan administrator.`);
-                break;
-            }
-            case 23: {
-                console.error(`KLA Error ${kiuwanRetCode}: Bad Credentials. User-supplied credentials are not valid. Contact your Kiuwan administrator.`);
-                break;
-            }
-            case 24: {
-                console.error(`KLA Error ${kiuwanRetCode}: Application Not Found. The invoked action cannot be completed because the associated application does not exist. Review log files to find exact cause and contact your Kiuwan administrator.`);
-                break;
-            }
-            case 25: {
-                console.error(`KLA Error ${kiuwanRetCode}: Limit Exceeded for Calls to Kiuwan API. Limit of max Kiuwan API calls per hour has been exceeded.	Contact Kiuwan Technical Support if you have any question on your acccount’s limits.`);
-                break;
-            }
-            case 26: {
-                console.error(`KLA Error ${kiuwanRetCode}: Quota Limit Reached. Some limit in the Kiuwan account is reached (max number of account’s analysis is reached, etc.). Contact Kiuwan Technical Support if you have any question on your acccount’s limits.`);
-                break;
-            }
-            case 27: {
-                console.error(`KLA Error ${kiuwanRetCode}: Analysis Not Found. The invoked action cannot be completed because the associated analysis does not exist. Review log files to find exact cause. Contact Kiuwan Technical Support`);
-                break;
-            }
-            case 28: {
-                console.error(`KLA Error ${kiuwanRetCode}: Application already exists`);
-                break;
-            }
-            default: {
-                console.log(`KLA returned ${kiuwanRetCode} Analysis finished successfully!`);
-            }
-        }
+        checkKuwanRetCode(kiuwanRetCode);
+
         if (kiuwanRetCode !== 0) {
             let taskFailedMsg = failOnAudit ? 'Kiuwan Audit FAILED! Task fails as instructed.' : 'Kiuwan analysis failed! See messages above.';
             tl.setResult(tl.TaskResult.Failed, taskFailedMsg);
@@ -231,86 +151,6 @@ async function run() {
         tl.setResult(tl.TaskResult.Failed, err.message);
         console.error('Task failed: ' + err.message);
     }
-}
-
-async function buildKlaCommand(klaPath: string, platform: string, chmod?: boolean) {
-    let command: string;
-    let defaultKiuwanDir: string = 'KiuwanLocalAnalyzer';
-    let dirExist: boolean;
-
-    if (platform === 'linux' || platform === 'darwin') {
-        // Define the KLA command if install directory exisits
-        dirExist = _exist(`${klaPath}/${defaultKiuwanDir}`);
-        console.log(`${klaPath}/${defaultKiuwanDir}: ${dirExist}`);
-        command = dirExist ? `${klaPath}/KiuwanLocalAnalyzer/bin/agent.sh` : "";
-        if (chmod) {
-            let ret = await tl.exec('chmod', `+x ${klaPath}/KiuwanLocalAnalyzer/bin/agent.sh`);
-            console.error(`chmod retuned: ${ret}`);
-        }
-    }
-    else {
-        dirExist = _exist(`${klaPath}\\${defaultKiuwanDir}`);
-        command = dirExist ? `${klaPath}\\KiuwanLocalAnalyzer\\bin\\agent.cmd` : "";
-    }
-
-    return command;
-}
-
-async function downloadInstallKla(platform: string) {
-
-    let downloadPath: string = await ttl.downloadTool('https://www.kiuwan.com/pub/analyzer/KiuwanLocalAnalyzer.zip', 'KiuwanLocalAnalyzer.zip');
-
-    let extPath: string = await ttl.extractZip(downloadPath);
-
-    // the extractZip tool ALWAYS extracts to a uuidv4 created directory.
-    // for pricvate agents we want to move the KLA directory to the Agent.HomeDirectory
-    let origPath: string;
-    let destPath: string;
-    if (platform === 'linux' || platform === 'darwin') {
-        origPath = `${extPath}/KiuwanLocalAnalyzer`
-        destPath = path.normalize(`${agentHomeDir}`);
-        let ret = await tl.exec('mv', `${origPath} ${destPath}`);
-        if (ret != 0) {
-            console.error(`Error moving KLA installation. mv returned: ${ret}`);
-        }
-    }
-    else {
-        origPath = `${extPath}\\KiuwanLocalAnalyzer`
-        destPath = path.normalize(`${agentHomeDir}`);
-        let ret = await tl.exec('powershell', `-command "Move-Item -Path '${origPath}' -Destination '${destPath}'"`);
-        if (ret != 0) {
-            console.error(`Error moving KLA installation. Move-Item returned: ${ret}`);
-        }
-    }
-
-    return destPath;
-}
-
-async function runKiuwanLocalAnalyzer(command: string, args: string) {
-    let exitCode: Number = 0;
-
-    // Run KLA with ToolRunner
-    let kiuwan = tl.tool(command).line(args);
-
-    let options = <trm.IExecOptions>{
-        cwd: '.',
-        env: process.env,
-        silent: false,
-        windowsVerbatimArguments: false,
-        failOnStdErr: false,
-        errStream: process.stdout,
-        outStream: process.stdout,
-        ignoreReturnCode: true
-    }
-
-    kiuwan.on('stdout', (data) => {
-        let output = data.toString().trim();
-        tl.debug(output);
-    })
-
-    exitCode = await kiuwan.exec(options);
-
-    return exitCode;
 }
 
 run();

--- a/delivery-analysis-task/index.ts
+++ b/delivery-analysis-task/index.ts
@@ -50,13 +50,41 @@ async function run() {
             technologies += dbtechnology;
         }
 
+        // Get the Kiuwan connection service authorization
+        let kiuwanConnection = tl.getInput("kiuwanConnection", true);
+        let kiuwanEndpointAuth = tl.getEndpointAuthorization(kiuwanConnection,true);
+        // Get user and password from variables defined in the build, otherwise get them from
+        // the Kiuwan service endpoint authorization
+        let kiuwanUser = tl.getVariable('KiuwanUser');
+        if (kiuwanUser === undefined || kiuwanUser === "") {
+            kiuwanUser = kiuwanEndpointAuth.parameters["username"];
+        }
+        let kiuwanPasswd = tl.getVariable('KiuwanPasswd');
+        if (kiuwanPasswd === undefined || kiuwanPasswd === "") {
+            kiuwanPasswd = kiuwanEndpointAuth.parameters["password"];
+        }
+
         // Get other relevant Variables from the task
         let buildNumber = tl.getVariable('Build.BuildNumber');
         let changeRequest = tl.getVariable('Build.SourceBranchName');
         let branchName = tl.getVariable('Build.SourceBranchName');
-        let kiuwanUser = tl.getVariable('KiuwanUser');
-        let kiuwanPasswd = tl.getVariable('KiuwanPasswd');
-        let projectName = tl.getVariable('System.TeamProject');
+        // Now the project name may come from different sources
+        // the System.TeamProject variable, an existing Kiuwan app name or a new one
+        let projectSelector = tl.getInput('projectnameselector');
+        let projectName = '';
+        if (projectSelector === 'default') {
+            projectName = tl.getVariable('System.TeamProject');
+            console.log(`Kiuwan application from System.TeamProject: ${projectName}`);
+        }
+        if (projectSelector === 'kiuwanapp') {
+            projectName = tl.getInput('kiuwanappname');
+            console.log(`Kiuwan application from Kiuwan app list: ${projectName}`);
+        }
+        if (projectSelector === 'appname') {
+            projectName = tl.getInput('customappname');
+            console.log(`Kiuwan application from user input: ${projectName}`);
+        }
+        
         let sourceDirectory = tl.getVariable('Build.SourcesDirectory');
         let agentName = tl.getVariable('Agent.Name');
 

--- a/delivery-analysis-task/index.ts
+++ b/delivery-analysis-task/index.ts
@@ -190,7 +190,7 @@ async function run() {
                 console.error(`KLA Error ${kiuwanRetCode}: Error checking license. Error while getting or checking Kiuwan license	Contact Kiuwan Technical Support`);
                 break;
             }
-            case 20: {
+            case 22: {
                 console.error(`KLA Error ${kiuwanRetCode}: Access denied. Lack of permissions to access some Kiuwan entity (application analyses, deliveries, etc). Review log files to find exact cause and contact your Kiuwan administrator.`);
                 break;
             }
@@ -257,10 +257,6 @@ async function buildKlaCommand(klaPath: string, platform: string, chmod?: boolea
 }
 
 async function downloadInstallKla(platform: string) {
-    // The downloadTool ALWAYS downloads to the AgentTempDirectory.
-    // For private agents,We set the AgentTemDirectory variable to AgentHome directory 
-    // to install it there (insubsiquent task runs we check for it there)
-    tl.setVariable('Agent.TempDirectory', agentHomeDir);
 
     let downloadPath: string = await ttl.downloadTool('https://www.kiuwan.com/pub/analyzer/KiuwanLocalAnalyzer.zip', 'KiuwanLocalAnalyzer.zip');
 
@@ -272,7 +268,7 @@ async function downloadInstallKla(platform: string) {
     let destPath: string;
     if (platform === 'linux' || platform === 'darwin') {
         origPath = `${extPath}/KiuwanLocalAnalyzer`
-        destPath = path.normalize(`${extPath}/..`);
+        destPath = path.normalize(`${agentHomeDir}`);
         let ret = await tl.exec('mv', `${origPath} ${destPath}`);
         if (ret != 0) {
             console.error(`Error moving KLA installation. mv returned: ${ret}`);
@@ -280,7 +276,7 @@ async function downloadInstallKla(platform: string) {
     }
     else {
         origPath = `${extPath}\\KiuwanLocalAnalyzer`
-        destPath = path.normalize(`${extPath}\\..`);
+        destPath = path.normalize(`${agentHomeDir}`);
         let ret = await tl.exec('powershell', `-command "Move-Item -Path '${origPath}' -Destination '${destPath}'"`);
         if (ret != 0) {
             console.error(`Error moving KLA installation. Move-Item returned: ${ret}`);

--- a/delivery-analysis-task/task.json
+++ b/delivery-analysis-task/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 1,
-        "Patch": 2
+        "Patch": 11
     },
     "visibility": [
         "Build",

--- a/delivery-analysis-task/task.json
+++ b/delivery-analysis-task/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 2,
-        "Patch": 3
+        "Patch": 6
     },
     "visibility": [
         "Build",

--- a/delivery-analysis-task/task.json
+++ b/delivery-analysis-task/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 2,
-        "Patch": 1
+        "Patch": 3
     },
     "visibility": [
         "Build",

--- a/delivery-analysis-task/task.json
+++ b/delivery-analysis-task/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 1
     },
     "visibility": [
         "Build",
@@ -43,7 +43,7 @@
             "type": "connectedService:Kiuwan",
             "label": "Kiuwan Service",
             "defaultValue": "",
-            "required": true,
+            "required": false,
             "helpMarkDown": "Kiuwan service connection"
         },
         {
@@ -53,7 +53,7 @@
             "defaultValue": "default",
             "required": true,
             "options": {
-                "default": "System.TeamProject",
+                "default": "$(System.TeamProject)",
                 "kiuwanapp": "Kiuwan application from list",
                 "appname": "Define a custom name"
             },

--- a/delivery-analysis-task/task.json
+++ b/delivery-analysis-task/task.json
@@ -8,8 +8,8 @@
     "author": "Javier Salado",
     "version": {
         "Major": 2,
-        "Minor": 1,
-        "Patch": 11
+        "Minor": 2,
+        "Patch": 0
     },
     "visibility": [
         "Build",
@@ -39,6 +39,44 @@
     ],
     "inputs": [
         {
+            "name": "kiuwanConnection",
+            "type": "connectedService:Kiuwan",
+            "label": "Kiuwan Service",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "Kiuwan service connection"
+        },
+        {
+            "name": "projectnameselector",
+            "type": "radio",
+            "label": "What do you want to use as Kiuwan application name?",
+            "defaultValue": "default",
+            "required": true,
+            "options": {
+                "default": "System.TeamProject",
+                "kiuwanapp": "Kiuwan application from list",
+                "appname": "Define a custom name"
+            },
+            "helpMarkDown": "You can use System.TeamProject variable, pick an aexisting application from a list or set a new application name."
+        },
+        {
+            "name": "kiuwanappname",
+            "type": "pickList",
+            "label": "Available Kiuwan applications",
+            "required": false,
+            "visibleRule": "projectnameselector = kiuwanapp",
+            "helpMarkDown": "Select an existing application in Kiuwan to associate results to."
+        },
+        {
+            "name": "customappname",
+            "type": "string",
+            "label": "Kiuwan application name",
+            "defaultValue": "",
+            "required": false,
+            "visibleRule": "projectnameselector = appname",
+            "helpMarkDown": "Custom application name in Kiuwan to associate results to. It will be cautomatically created if it doesn't exist in your account."
+        },
+        {
             "name": "analysislabel",
             "type": "string",
             "label": "Analysis label",
@@ -46,7 +84,8 @@
             "required": false,
             "helpMarkDown": "A label to identify this analysis in Kiuwan. The build number is always appended to the specified label. if empty, the label will be the build number."
         },
-        {   "name": "analysisscope",
+        {
+            "name": "analysisscope",
             "type": "radio",
             "label": "Anlysis Scope",
             "defaultValue": "completeDelivery",
@@ -83,7 +122,8 @@
             "groupName": "security",
             "helpMarkDown": "Skipping the architecture code analysis is recommended for code security analysis only."
         },
-        {   "name": "crstatus",
+        {
+            "name": "crstatus",
             "type": "radio",
             "label": "Change request status",
             "defaultValue": "inprogress",
@@ -163,6 +203,13 @@
                 "informix": "Informix stored procedures"
             },
             "helpMarkDown": "Please, select the type of stored procedures you use in your application. We support Oracle PL/SQL, Microsoft SQLServer TransactSQL, Sybase Transact and Informix stored procedures."
+        }
+    ],
+    "dataSourceBindings": [
+        {
+            "target": "kiuwanappname",
+            "endpointId": "$(kiuwanConnection)",
+            "dataSourceName": "ListApplications"
         }
     ],
     "execution": {

--- a/kiuwan-common/utils.ts
+++ b/kiuwan-common/utils.ts
@@ -1,0 +1,188 @@
+import tl = require('vsts-task-lib/task');
+import ttl = require('vsts-task-tool-lib/tool')
+import trm = require('vsts-task-lib/toolrunner');
+import fs = require('fs');
+import { extractZip } from 'vsts-task-tool-lib/tool';
+import { _exist } from 'vsts-task-lib/internal';
+
+export async function buildKlaCommand(klaPath: string, platform: string) {
+    let command: string;
+    let defaultKiuwanDir: string = 'KiuwanLocalAnalyzer';
+    let dirExist: boolean;
+
+    if (platform === 'linux' || platform === 'darwin') {
+        // Define the KLA command if install directory exisits
+        dirExist = _exist(`${klaPath}/${defaultKiuwanDir}`);
+        console.log(`${klaPath}/${defaultKiuwanDir}: ${dirExist}`);
+        command = dirExist ? `${klaPath}/${defaultKiuwanDir}/bin/agent.sh` : "";
+    }
+    else {
+        dirExist = _exist(`${klaPath}\\${defaultKiuwanDir}`);
+        command = dirExist ? `${klaPath}\\${defaultKiuwanDir}\\bin\\agent.cmd` : "";
+    }
+
+    return command;
+}
+
+export async function downloadInstallKla(toolName: string, toolVersion: string, platform: string) {
+    let defaultKiuwanDir: string = 'KiuwanLocalAnalyzer';
+
+    let toolPath = ttl.findLocalTool(toolName, toolVersion);
+
+    if (!toolPath) {
+        let downloadPath: string = await ttl.downloadTool('https://www.kiuwan.com/pub/analyzer/KiuwanLocalAnalyzer.zip', 'KiuwanLocalAnalyzer.zip');
+
+        let extPath: string = await ttl.extractZip(downloadPath);
+
+        toolPath = await ttl.cacheDir(extPath, toolName, toolVersion);
+        // Setting +x permision to the kla shell script in unix based platforms
+        if (platform === 'linux' || platform === 'darwin') {
+            let ret = await tl.exec('chmod', `+x ${toolPath}/${defaultKiuwanDir}/bin/agent.sh`);
+            console.error(`chmod retuned: ${ret}`);
+        }
+        console.log(`KLA downloaded and  installed in ${toolPath}`)
+    }
+
+    return toolPath;
+}
+
+export async function runKiuwanLocalAnalyzer(command: string, args: string) {
+    let exitCode: Number = 0;
+
+    // Run KLA with ToolRunner
+    let kiuwan = tl.tool(command).line(args);
+
+    let options = <trm.IExecOptions>{
+        cwd: '.',
+        env: process.env,
+        silent: false,
+        windowsVerbatimArguments: false,
+        failOnStdErr: false,
+        errStream: process.stdout,
+        outStream: process.stdout,
+        ignoreReturnCode: true
+    }
+
+    kiuwan.on('stdout', (data) => {
+        let output = data.toString().trim();
+        tl.debug(output);
+    })
+
+    exitCode = await kiuwan.exec(options);
+
+    return exitCode;
+}
+
+export function setAgentTempDir(agentHomeDir: string, platform: string) {
+    let tempDir: string;
+    if (platform === 'linux' || platform === 'darwin') {
+        tempDir = `${agentHomeDir}/_temp`
+    }
+    else {
+        tempDir = `${agentHomeDir}\\_temp`
+    }
+
+    // Creates the temp directory if it doesn't exists
+    if (! _exist(tempDir)) {
+        fs.mkdirSync(tempDir);
+    }
+
+    tl.setVariable('Agent.TempDirectory', tempDir);
+
+    return tempDir;
+}
+
+export function setAgentToolsDir(agentHomeDir: string, platform: string) {
+    let toolsDir: string;
+    if (platform === 'linux' || platform === 'darwin') {
+        toolsDir = `${agentHomeDir}/_tools`
+    }
+    else {
+        toolsDir = `${agentHomeDir}\\_tools`
+    }
+
+    tl.setVariable('Agent.ToolsDirectory', toolsDir);
+
+    return toolsDir;
+}
+
+export function checkKuwanRetCode(kiuwanRetCode: Number) {
+    switch (kiuwanRetCode) {
+        case 1: {
+            console.error(`KLA Error ${kiuwanRetCode}: Analyzer execution error .Run-time execution error (out of memory, etc.). Review log files to find exact cause.`);
+            break;
+        }
+        case 10: {
+            console.error(`KLA Error ${kiuwanRetCode}: Audit overall result = FAIL. Audit associated to the analyzed application did not pass. See audit report for exact reasons of non compliance (checkpoints not passed, etc.)`);
+            break;
+        }
+        case 11: {
+            console.error(`KLA Error ${kiuwanRetCode}: Invalid analysis configuration. Some configuration parameter has a wrong value. Review log files to find exact cause`);
+            break;
+        }
+        case 12: {
+            console.error(`KLA Error ${kiuwanRetCode}: The downloaded model does not support any of the discovered languages. The model specified for the application does not contains rules for the technologies being analyzed. Select an appropriate model or modify the model to include those technologies not currently supported`);
+            break;
+        }
+        case 13: {
+            console.error(`KLA Error ${kiuwanRetCode}: Timeout waiting for analysis results. After finishing the local analysis, results were uploaded to Kiuwan site but the second phase (index calculation) timed out. A very common reason for this problem is when your account has reached the maximun number of analyzed locs per 24h. In this case, your analysis is enqueued and local analyzer times out. This does not mean that the analysis has failed. Indeed, the analysis is only enqueued and it will be processed as soon as the limit is over. In this situation you don't need to execute again the analysis, just wait, it will be run automatically.`);
+            break;
+        }
+        case 14: {
+            console.error(`KLA Error ${kiuwanRetCode}: Analysis finished with error in Kiuwan. Although local analysis finished successfully, there was some error during analysis processing in the cloud. Visit the log page associated to the analysis.`);
+            break;
+        }
+        case 15: {
+            console.error(`KLA Error ${kiuwanRetCode}: Timeout: killed the subprocess. Local analysis timed out. Increase timeout value to a higher value.`);
+            break;
+        }
+        case 16: {
+            console.error(`KLA Error ${kiuwanRetCode}: Account limits exceeded. Some limit in the Kiuwan account is reached (max number of account’s analysis is reached, etc.). Contact Kiuwan Technical Support if you have any question on your acccount’s limits.`);
+            break;
+        }
+        case 17: {
+            console.error(`KLA Error ${kiuwanRetCode}: Delivery analysis not permitted for current user. User does not have permission to run delivery analysis for the current application.	Check the user has “Execute deliveries” privilege on the application.`);
+            break;
+        }
+        case 18: {
+            console.error(`KLA Error ${kiuwanRetCode}: No analyzable extensions found. Kiuwan recognizes the technology of a source file by its extension. But source files to analyze do not match any of the recognized extensions.`);
+            break;
+        }
+        case 19: {
+            console.error(`KLA Error ${kiuwanRetCode}: Error checking license. Error while getting or checking Kiuwan license	Contact Kiuwan Technical Support`);
+            break;
+        }
+        case 22: {
+            console.error(`KLA Error ${kiuwanRetCode}: Access denied. Lack of permissions to access some Kiuwan entity (application analyses, deliveries, etc). Review log files to find exact cause and contact your Kiuwan administrator.`);
+            break;
+        }
+        case 23: {
+            console.error(`KLA Error ${kiuwanRetCode}: Bad Credentials. User-supplied credentials are not valid. Contact your Kiuwan administrator.`);
+            break;
+        }
+        case 24: {
+            console.error(`KLA Error ${kiuwanRetCode}: Application Not Found. The invoked action cannot be completed because the associated application does not exist. Review log files to find exact cause and contact your Kiuwan administrator.`);
+            break;
+        }
+        case 25: {
+            console.error(`KLA Error ${kiuwanRetCode}: Limit Exceeded for Calls to Kiuwan API. Limit of max Kiuwan API calls per hour has been exceeded.	Contact Kiuwan Technical Support if you have any question on your acccount’s limits.`);
+            break;
+        }
+        case 26: {
+            console.error(`KLA Error ${kiuwanRetCode}: Quota Limit Reached. Some limit in the Kiuwan account is reached (max number of account’s analysis is reached, etc.). Contact Kiuwan Technical Support if you have any question on your acccount’s limits.`);
+            break;
+        }
+        case 27: {
+            console.error(`KLA Error ${kiuwanRetCode}: Analysis Not Found. The invoked action cannot be completed because the associated analysis does not exist. Review log files to find exact cause. Contact Kiuwan Technical Support`);
+            break;
+        }
+        case 28: {
+            console.error(`KLA Error ${kiuwanRetCode}: Application already exists`);
+            break;
+        }
+        default: {
+            console.log(`KLA returned ${kiuwanRetCode} Analysis finished successfully!`);
+        }
+    }
+
+}

--- a/overview.md
+++ b/overview.md
@@ -1,12 +1,14 @@
 The Kiuwan extension for FTS and VSTS includes 2 new build tasks to run Kiuwan analyses as part of your application builds.
 
+With the latest version, you can now define a Kiuwan service endpoint. This will allow you store you Kiuwan credenyial at the project level. At the same time this service endpoint allows the extension to get information from your Kiuwan account to provide new exciting features and more to come.
+
 ## What you need to know before installing it ##
 
 This extension works with the Kiuwan Application Security platform in the cloud. So you need a Kiuwan account to use it.
 
 The included build tasks will work on TFS Windows, Linux or MacOS agents and VSTS private or hosted Windows, Linux and MacOS agents.
 
-For private agents, you can download the Kiuwan Local Analyzer (KLA) from your Kiuwan account and pre-install it in the agent machines you want to use. Make sure you define the KIUWAN_HOME evironment variable pointing to the directory where you installed the KLA (i.e. C:\KiuwanLocalAnalyzer). If you don't pre-install the KLA, the first time you run a Kiuwan task the KLA will be downloaded and intalled in the agent home directory that ran the Kiuwan build task. Next time the same agent runs a Kiuwan task it will use that installation.
+For private agents, you can download the Kiuwan Local Analyzer (KLA) from your Kiuwan account and pre-install it in the agent machines you want to use. Make sure you define the KIUWAN_HOME evironment variable pointing to the directory where you installed the KLA (i.e. C:\KiuwanLocalAnalyzer). If you don't pre-install the KLA, the first time you run a Kiuwan task the KLA will be downloaded and installed in the agent home directory that ran the Kiuwan build task. Next time the same agent runs a Kiuwan task it will use that installation.
 
 For hosted agents (that are spawned dynamicaly), the KLA is downloaded and installed every time a Kiuwan task runs.
 
@@ -14,7 +16,20 @@ For hosted agents (that are spawned dynamicaly), the KLA is downloaded and insta
 
 ## What you get with the extension ##
 
-2 new build tasks. Stay tuned for more amazing stuff to come!
+A service endpoint type and 2 build tasks. One to run Kiuwan baseline analyses to analyse your realeases. And one to run Kiuwan delivery analyses for your change or pull requests.
+
+- **New Service Endpoint type.** To connect to the Kiuwan platform form TFS/VSTS. Now you can define a new service endpoint to the Kiuwan platform. You just need to select the Kiuwan Platform service connection type from the "New Service Enpoint" pulldown in the TFS/VSTS Services configuration tab.
+
+<img src="https://www.kiuwan.com/wp-content/uploads/2018/03/vsts-services.png">
+
+<img src="https://www.kiuwan.com/wp-content/uploads/2018/03/new-service-endpoint.png">
+
+Then you just configure a name for the Kiuwan connection and your Kiuwan account credentials to use to connect to Kiuwan.
+
+<img src="https://www.kiuwan.com/wp-content/uploads/2018/03/kiuwan-endpoint-config.png">
+
+### **NOTE**: Kiuwan credentials for your build tasks
+You can now configure the Kiuwan connection in your exisitng tasks. The credentials configured the selected Kiuwan connection will be used to run the analysis. For backward compatibility, if you don't configure the Kiuwan connection in the task, the build definition variables: KiuwanUser and KiuwanPasswd, will be use for credentials. These variables can be used as well to override the Kiuwan connection credentials. This can be useful if you want a particular build definition to run analyses with a different user.
 
 <img src="https://www.kiuwan.com/wp-content/uploads/2018/01/kiuwan-tasks.png">
 
@@ -26,6 +41,5 @@ For hosted agents (that are spawned dynamicaly), the KLA is downloaded and insta
 
 <img src="https://www.kiuwan.com/wp-content/uploads/2018/01/kiuwan-audit-results.png">
 
-### **NOTE**: Kiuwan credentials configuration settings
-Running Kiuwan analysis requires authentication with your Kiuwan account. You will need to define the KiuwanUser and KiuwanPasswd variables in your build definitions running the build tasks from this plugin.
-
+### **NOTE**: Kiuwan application selection
+By default, we use the project name as the application name in Kiuwan the results are uploaded to. However, you can override this behavior in a task, picking the application from a list with the existing applications in your Kiuwan account (bear in mind than the application list in the combo depend on the permisions the Kiuwan user defined in the Kiuwan connection), or entering a new application name.

--- a/overview.md
+++ b/overview.md
@@ -8,7 +8,9 @@ This extension works with the Kiuwan Application Security platform in the cloud.
 
 The included build tasks will work on TFS Windows, Linux or MacOS agents and VSTS private or hosted Windows, Linux and MacOS agents.
 
-For private agents, you can download the Kiuwan Local Analyzer (KLA) from your Kiuwan account and pre-install it in the agent machines you want to use. Make sure you define the KIUWAN_HOME evironment variable pointing to the directory where you installed the KLA (i.e. C:\KiuwanLocalAnalyzer). If you don't pre-install the KLA, the first time you run a Kiuwan task the KLA will be downloaded and installed in the agent home directory that ran the Kiuwan build task. Next time the same agent runs a Kiuwan task it will use that installation.
+For private agents, you can download the Kiuwan Local Analyzer (KLA) from your Kiuwan account and pre-install it in the agent machines you want to use. Make sure you define the KIUWAN_HOME evironment variable pointing to the directory where you installed the KLA (i.e. C:\KiuwanLocalAnalyzer). If you don't pre-install the KLA, the first time you run a Kiuwan task the KLA will be downloaded and installed in the agent tools directory that ran the Kiuwan build task. Next time the same agent runs a Kiuwan task it will use that installation.
+
+If the Agent.TempDirectory and the the Agent.ToolsDirectory variables are not set in your private agents they are set by the build tasks to ${Agent.HomeDirectory}/_temp and ${Agent.ToolsDirectpry}/_tools respectively for the tasks to work properly.
 
 For hosted agents (that are spawned dynamicaly), the KLA is downloaded and installed every time a Kiuwan task runs.
 

--- a/overview.md
+++ b/overview.md
@@ -18,7 +18,7 @@ For hosted agents (that are spawned dynamicaly), the KLA is downloaded and insta
 
 A service endpoint type and 2 build tasks. One to run Kiuwan baseline analyses to analyse your realeases. And one to run Kiuwan delivery analyses for your change or pull requests.
 
-- **New Service Endpoint type.** To connect to the Kiuwan platform form TFS/VSTS. Now you can define a new service endpoint to the Kiuwan platform. You just need to select the Kiuwan Platform service connection type from the "New Service Enpoint" pulldown in the TFS/VSTS Services configuration tab.
+- **New Service Endpoint type.** To connect to the Kiuwan platform form TFS/VSTS. Now you can define a new service endpoint to the Kiuwan platform. You just need to select the Kiuwan Platform service connection type from the "New Service Endpoint" pulldown in the TFS/VSTS Services configuration tab.
 
 <img src="https://www.kiuwan.com/wp-content/uploads/2018/03/vsts-services.png">
 
@@ -29,11 +29,11 @@ Then you just configure a name for the Kiuwan connection and your Kiuwan account
 <img src="https://www.kiuwan.com/wp-content/uploads/2018/03/kiuwan-endpoint-config.png">
 
 ### **NOTE**: Kiuwan credentials for your build tasks
-You can now configure the Kiuwan connection in your exisitng tasks. The credentials configured the selected Kiuwan connection will be used to run the analysis. For backward compatibility, if you don't configure the Kiuwan connection in the task, the build definition variables: KiuwanUser and KiuwanPasswd, will be use for credentials. These variables can be used as well to override the Kiuwan connection credentials. This can be useful if you want a particular build definition to run analyses with a different user.
+You can now configure the Kiuwan connection in your existing tasks. The credentials configured the selected Kiuwan connection will be used to run the analysis. For backward compatibility, if you don't configure the Kiuwan connection in the task, the build definition variables: KiuwanUser and KiuwanPasswd, will be use for credentials. These variables can be used as well to override the Kiuwan connection credentials. This can be useful if you want a particular build definition to run analyses with a different user.
 
 <img src="https://www.kiuwan.com/wp-content/uploads/2018/01/kiuwan-tasks.png">
 
-- **Kiuwan Baseline Anlysis.** This task will run a Kiuwan baseline analysis as part of your build definition. The results are automatically uploaded to your Kiuwan account in the cloud where you can see the results and browse through the security vulnerabilities and other relevant defects  found in your applications.
+- **Kiuwan Baseline Analysis.** This task will run a Kiuwan baseline analysis as part of your build definition. The results are automatically uploaded to your Kiuwan account in the cloud where you can see the results and browse through the security vulnerabilities and other relevant defects  found in your applications.
 
 <img src="https://www.kiuwan.com/wp-content/uploads/2018/01/analysis-results.png">
 

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "kiuwan-analysis-extension",
     "name": "Kiuwan analysis",
-    "version": "2.1.2",
+    "version": "2.1.11",
     "publisher": "kiuwan-publisher",
     "targets": [
         {
@@ -21,15 +21,15 @@
             "uri": "https://www.kiuwan.com"
         },
         "repository": {
-            "uri": "https://github.com/jsalado/kiuwan-vsts-extension"
+            "uri": "https://github.com/kiuwan/tfs-vsts-extension"
         },
         "issues": {
-            "uri": "https://github.com/jsalado/kiuwan-vsts-extension/issues"
+            "uri": "https://github.com/kiuwan/tfs-vsts-extension/issues"
         }
     },
     "repository": {
         "type": "git",
-        "uri": "https://github.com/jsalado/kiuwan-vsts-extension"
+        "uri": "https://github.com/kiuwan/tfs-vsts-extension"
     },
     "branding": {
         "color": "#01a4a6",
@@ -94,6 +94,65 @@
             ],
             "properties": {
                 "name": "delivery-analysis-task"
+            }
+        },
+        {
+            "id": "kiuwan-service-endpoint",
+            "description": "Kiuwan servide endpoint to connect to the Kiuwan platform",
+            "type": "ms.vss-endpoint.service-endpoint-type",
+            "targets": [
+                "ms.vss-service.endpont-types"
+            ],
+            "properties": {
+                "name": "kiuwan",
+                "displayName": "Kiuwan Platform",
+                "icon": "images/kiuwan-extension.png",
+                "url": {
+                    "displayName": "Kiuwan URL",
+                    "value": "https://api.kiuwan.com",
+                    "helpMarkDown": "Please unless you have an Kiuwan on-premise installation the Kiuwan Service Endpoint URL is always https://api.kiuwan.com"
+                },
+                "dataSources": [
+                    {
+                        "name": "TestConnection",
+                        "endpointUrl": "{{endpoint.url}}/info",
+                        "resultSelector": "jsonpath:$[*].Key"
+                    }
+                ],
+                "authenticationSchemes": [
+                    {
+                        "type": "ms.vss-endpoint.endpoint-auth-scheme-basic",
+                        "inputDescriptors": [
+                            {
+                                "id": "username",
+                                "name": "Username",
+                                "description": "Kiuwan username",
+                                "inputMode": "textbox",
+                                "isConfidentioal": false,
+                                "validation": {
+                                    "isrequired": false,
+                                    "dataType": "string"
+                                }
+                            },
+                            {
+                                "id": "password",
+                                "name": "Password",
+                                "description": "Kiuwan password",
+                                "inputMode": "passwordBox",
+                                "isConfidentioal": true,
+                                "validation": {
+                                    "isrequired": false,
+                                    "dataType": "string"
+                                },
+                                "values": {
+                                    "inputId": "passwordInput",
+                                    "defaultValue": ""
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "helpMarkdown": "<a href=\"https://www.kiuwam.com\" target=\"_blank\"><b>Learn More</b></a>"
             }
         }
     ]

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "kiuwan-analysis-extension",
     "name": "Kiuwan analysis",
-    "version": "2.2.3",
+    "version": "2.2.6",
     "publisher": "kiuwan-publisher",
     "targets": [
         {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "kiuwan-analysis-extension",
     "name": "Kiuwan analysis",
-    "version": "2.1.11",
+    "version": "2.2.0",
     "publisher": "kiuwan-publisher",
     "targets": [
         {
@@ -100,23 +100,25 @@
             "id": "kiuwan-service-endpoint",
             "description": "Kiuwan servide endpoint to connect to the Kiuwan platform",
             "type": "ms.vss-endpoint.service-endpoint-type",
-            "targets": [
-                "ms.vss-service.endpont-types"
-            ],
+            "targets": [ "ms.vss-endpoint.endpoint-types" ],
             "properties": {
                 "name": "kiuwan",
                 "displayName": "Kiuwan Platform",
-                "icon": "images/kiuwan-extension.png",
                 "url": {
                     "displayName": "Kiuwan URL",
                     "value": "https://api.kiuwan.com",
-                    "helpMarkDown": "Please unless you have an Kiuwan on-premise installation the Kiuwan Service Endpoint URL is always https://api.kiuwan.com"
+                    "helpMarkDown": "The Kiuwan Service Endpoint URL is always https://api.kiuwan.com"
                 },
                 "dataSources": [
                     {
                         "name": "TestConnection",
                         "endpointUrl": "{{endpoint.url}}/info",
-                        "resultSelector": "jsonpath:$[*].Key"
+                        "resultSelector": "jsonpath:$.username"
+                    },
+                    {
+                        "name": "ListApplications",
+                        "endpointUrl": "{{endpoint.url}}/apps/list",
+                        "resultSelector": "jsonpath:$[*].name"
                     }
                 ],
                 "authenticationSchemes": [
@@ -126,27 +128,23 @@
                             {
                                 "id": "username",
                                 "name": "Username",
-                                "description": "Kiuwan username",
+                                "description": "This is your Kiuwan username",
                                 "inputMode": "textbox",
-                                "isConfidentioal": false,
+                                "isConfidential": false,
                                 "validation": {
-                                    "isrequired": false,
+                                    "isrequired": true,
                                     "dataType": "string"
                                 }
                             },
                             {
                                 "id": "password",
                                 "name": "Password",
-                                "description": "Kiuwan password",
+                                "description": "Yup! this is your Kiuwan password",
                                 "inputMode": "passwordBox",
-                                "isConfidentioal": true,
+                                "isConfidential": true,
                                 "validation": {
-                                    "isrequired": false,
+                                    "isrequired": true,
                                     "dataType": "string"
-                                },
-                                "values": {
-                                    "inputId": "passwordInput",
-                                    "defaultValue": ""
                                 }
                             }
                         ]

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "kiuwan-analysis-extension",
     "name": "Kiuwan analysis",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "publisher": "kiuwan-publisher",
     "targets": [
         {
@@ -10,7 +10,7 @@
         }
     ],
     "public": true,
-    "description": "Analyze your applications with Kiuwan in your build pipelines. Find relevant security vulnerabilities in your code. Run automatic code security audits. Build secure applications from the start.",
+    "description": "Analyze your applications with Kiuwan in your build definitions. Find relevant security vulnerabilities in your code. Run automatic code security audits. Build secure applications from the start.",
     "content": {
         "details": {
             "path": "overview.md"

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "kiuwan-analysis-extension",
     "name": "Kiuwan analysis",
-    "version": "2.2.1",
+    "version": "2.2.3",
     "publisher": "kiuwan-publisher",
     "targets": [
         {


### PR DESCRIPTION
This is a step beyond @tasadar2 fix to not override the agent temp directory and leverage the agent tools directory to cache the KLA installation.
If the temp and tools directories variables are not set in the agent they are set to Agent.HomeDir/_temp and Agent.HomeDir/_tools respectively. This way there is never a conflict.
New kiuwan-common utils module with shared fuctionality for both tasks.