### PR TITLE
Fail on no files added for deliveries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.vsix
 *.code-workspace
 node_modules
+node_modules.remove
 ps_modules
 settings.json
 .eslint*
@@ -16,6 +17,8 @@ baseline-analysis-task/ps_modules
 delivery-analysis-task/ps_modules
 baseline-analysis-task/node_modules
 delivery-analysis-task/node_modules
+baseline-analysis-task/node_modules.remove
+delivery-analysis-task/node_modules.remove
 *.zip
 *.txt
 endpoin-definition.json

--- a/baseline-analysis-task/task.json
+++ b/baseline-analysis-task/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 2,
-        "Patch": 26
+        "Patch": 27
     },
     "visibility": [
         "Build",

--- a/delivery-analysis-task/task.json
+++ b/delivery-analysis-task/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 2,
-        "Patch": 26
+        "Patch": 27
     },
     "visibility": [
         "Build",
@@ -103,6 +103,15 @@
             "required": false,
             "visibleRule": "analysisscope = partialDelivery",
             "helpMarkDown": "Specify an alternative source code directory with the application changes only.<br />This directory could have been created by a previous custom task that extracts those changes from the repository.<br />You can use variables well known variable like $(Build.SourcesDirectory) to define it."
+        },
+        {
+            "name": "failonnofiles",
+            "type": "boolean",
+            "label": "Fail when no files to analyze?",
+            "defaultValue": true,
+            "required": true,
+            "visibleRule": "analysisscope = partialDelivery",
+            "helpMarkDown": "Should the task fail if the Kiuwan can't find any files to analyze?"
         },
         {
             "name": "failonaudit",

--- a/kiuwan-common/utils.ts
+++ b/kiuwan-common/utils.ts
@@ -194,3 +194,7 @@ export function getKiuwanRetMsg(kiuwanRetCode: Number): string {
 export function auditFailed(retCode: Number): boolean {
     return (retCode === 10);
 }
+
+export function noFilesToAnalyze(retCode: Number): boolean {
+    return (retCode === 18);
+}

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "kiuwan-analysis-extension",
     "name": "Kiuwan",
-    "version": "2.2.26",
+    "version": "2.2.27",
     "publisher": "kiuwan-publisher",
     "targets": [
         {
@@ -64,6 +64,9 @@
         "vso.work"
     ],
     "files": [
+        {
+            "path": "kiuwan-common"
+        },
         {
             "path": "baseline-analysis-task"
         },


### PR DESCRIPTION
Added a new check to decide if delivery analyses fail if there are no
files to analyze.
Necessary when analyzing changes only and there are no code changes.