### PR TITLE
Support for SSO Kiuwan accounts

### DIFF
--- a/baseline-analysis-task/index.ts
+++ b/baseline-analysis-task/index.ts
@@ -102,16 +102,25 @@ async function run() {
 
         // Get the Kiuwan connection service authorization
         let kiuwanEndpointAuth = tl.getEndpointAuthorization(kiuwanConnection, true);
-        // Get user and password from variables defined in the build, otherwise get them from
+        // Get user, password and domain ID from variables defined in the build, otherwise get them from
         // the Kiuwan service endpoint authorization
         let kiuwanUser = tl.getVariable('KiuwanUser');
         if (kiuwanUser === undefined || kiuwanUser === "") {
-            kiuwanUser = kiuwanEndpointAuth.parameters["username"];
+            //kiuwanUser = kiuwanEndpointAuth.parameters["username"];
+            kiuwanUser = tl.getEndpointAuthorizationParameter(kiuwanConnection, "username", false);
         }
         let kiuwanPasswd = tl.getVariable('KiuwanPasswd');
         if (kiuwanPasswd === undefined || kiuwanPasswd === "") {
-            kiuwanPasswd = kiuwanEndpointAuth.parameters["password"];
+            //kiuwanPasswd = kiuwanEndpointAuth.parameters["password"];
+            kiuwanPasswd = tl.getEndpointAuthorizationParameter(kiuwanConnection, "password", false);
         }
+        let kiuwanDomainId = tl.getVariable('KiuwanDomainId');
+        let kiuwanDomainId_d = '';
+        if (kiuwanDomainId === undefined || kiuwanDomainId === "") {
+            //kiuwanDomainId = kiuwanEndpointAuth.parameters["domainid"];
+            kiuwanDomainId = tl.getEndpointDataParameter(kiuwanConnection, "domainid", true);
+        }
+        debug(`[KW] Kiuwan auth domain: ${kiuwanDomainId}`);
 
         // Get other relevant Variables from the task
         let buildNumber = tl.getVariable('Build.BuildNumber');
@@ -177,6 +186,12 @@ async function run() {
                 `encoding=${encoding}`;
         }
 
+        let domainOption = ' ';
+        if (kiuwanDomainId !== undefined && kiuwanDomainId !== "" && kiuwanDomainId !== "0") {
+            domainOption = `--domain-id ${kiuwanDomainId} `;
+        }
+        debug(`[KW] Domain option: ${domainOption}`);
+
         let klaArgs: string =
             `-n "${projectName}" ` +
             `-s "${sourceDirectory}" ` +
@@ -185,6 +200,7 @@ async function run() {
             '-wr ' +
             `--user ${kiuwanUser} ` +
             `--pass ${kiuwanPasswd} ` +
+            `${domainOption}` +
             `${advancedArgs} ` +
             `supported.technologies=${technologies} ` +
             `memory.max=${memory} ` +
@@ -207,7 +223,7 @@ async function run() {
             }
             else {
                 let kiuwanEndpoint = `/saas/rest/v1/apps/${projectName}`;
-                let kiuwanAnalysisResult = await getLastAnalysisResults(kiuwanUrl, kiuwanUser, kiuwanPasswd, kiuwanEndpoint);
+                let kiuwanAnalysisResult = await getLastAnalysisResults(kiuwanUrl, kiuwanUser, kiuwanPasswd, kiuwanDomainId, kiuwanEndpoint);
 
                 tl.debug(`[KW] Result of last analysis for ${projectName}: ${kiuwanAnalysisResult}`);
 

--- a/baseline-analysis-task/task.json
+++ b/baseline-analysis-task/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 3,
-        "Patch": 36
+        "Patch": 44
     },
     "visibility": [
         "Build",

--- a/delivery-analysis-task/task.json
+++ b/delivery-analysis-task/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 3,
-        "Patch": 36
+        "Patch": 44
     },
     "visibility": [
         "Build"

--- a/kiuwan-common/utils.ts
+++ b/kiuwan-common/utils.ts
@@ -5,7 +5,7 @@ import path = require('path');
 import fs = require('fs');
 import https = require('https');
 import http = require('http');
-import { Url } from 'url';
+import { Url, domainToUnicode } from 'url';
 import { _exist } from 'vsts-task-lib/internal';
 
 export function isBuild(): boolean {
@@ -18,15 +18,15 @@ export function isBuild(): boolean {
     }
 }
 
-export async function getLastAnalysisResults(kiuwanUrl: Url, kiuwanUser: string, kiuwanPassword: string, kiuwanEndpoint: string) {
+export async function getLastAnalysisResults(kiuwanUrl: Url, kiuwanUser: string, kiuwanPassword: string, domainId: string, kiuwanEndpoint: string) {
     const method = 'GET';
     const auth = `${kiuwanUser}:${kiuwanPassword}`;
     const encodedPath = encodeURI(kiuwanEndpoint);
 
     var options: https.RequestOptions | http.RequestOptions;
-    var host = ( kiuwanUrl.host.indexOf(':') == -1) ? kiuwanUrl.host : kiuwanUrl.host.substring(0,kiuwanUrl.host.indexOf(':'));
+    var host = (kiuwanUrl.host.indexOf(':') == -1) ? kiuwanUrl.host : kiuwanUrl.host.substring(0, kiuwanUrl.host.indexOf(':'));
     tl.debug(`[KW] Host: ${host}`);
-     options = {
+    options = {
         protocol: kiuwanUrl.protocol,
         host: host,
         port: kiuwanUrl.port,
@@ -34,6 +34,10 @@ export async function getLastAnalysisResults(kiuwanUrl: Url, kiuwanUser: string,
         method: method,
         rejectUnauthorized: false,
         auth: auth
+    }
+
+    if (domainId !== undefined && domainId !== '' && domainId !== "0") {
+        options.headers = { 'X-KW-CORPORATE-DOMAIN-ID': domainId };
     }
 
     tl.debug(`[KW] kiuwan API call: ${kiuwanUrl.protocol}//${kiuwanUrl.host}${encodedPath}`);

--- a/overview.md
+++ b/overview.md
@@ -9,11 +9,13 @@ This extension works with the Kiuwan Application Security platform. So you need 
 
 The included build tasks will work on Windows, Linux or MacOS Azure DevOps Server (former TFS) agents and Azure DevOps private or hosted Windows, Linux and MacOS agents.
 
-For Azure DevOps Server and Azure DevOps private agents, you don't need to pre-install the Kiuwan Local Analyzer (KLA). The first time you run a Kiuwan task the KLA will be downloaded and installed in the agent tools directory that ran the Kiuwan build task. Next time the same agent runs a Kiuwan task it will use that installation. However, if you tighter control, you can download the Kiuwan Local Analyzer (KLA) from your Kiuwan account and pre-install it in the agent machines you want to use. Make sure you define the KIUWAN_HOME environment variable pointing to the directory where you installed the KLA (i.e. C:\KiuwanLocalAnalyzer).
+For Azure DevOps Server and Azure DevOps private agents, you don't need to pre-install the Kiuwan Local Analyzer (KLA). The first time you run a Kiuwan task the KLA will be downloaded and installed in the agent's tools directory (in a Windows host it is typically `C:\agent\_work\_tool`) that ran the Kiuwan build task. Next time the same agent runs a Kiuwan task it will use that installation. 
 
-If the Agent.TempDirectory and the the Agent.ToolsDirectory variables are not set in your private agents they are set by the build tasks to ${Agent.HomeDirectory}/_temp and ${Agent.ToolsDirectory}/_tools respectively for the tasks to work properly.
+If there are any issues with the KLA installation or you need to remove it to have fresh install in the next task run, go to that directory and just delete the `KiuwanLocalAnalyzer` folder found there.
 
-For hosted agents (that are spawned dynamically), the KLA is downloaded and installed every time a Kiuwan task runs.
+If the Agent.TempDirectory and the the Agent.ToolsDirectory variables are not set in your private agents they are set by the build tasks to `${Agent.HomeDirectory}/_temp` and `${Agent.ToolsDirectory}/_tools` respectively for the tasks to work properly.
+
+For hosted agents (that are provisioned dynamically), the KLA is downloaded and installed every time a Kiuwan task runs.
 
 ## What you get with the extension ##
 
@@ -27,7 +29,9 @@ A service endpoint type and 2 build tasks. One to run Kiuwan baseline analyses t
 
 Then you just configure a name for the Kiuwan connection, the URL of the Kiuwan platform you are using (cloud or on-premises) and your Kiuwan account credentials to use to connect to Kiuwan.
 
-<img src="https://www.kiuwan.com/wp-content/uploads/2018/03/kiuwan-endpoint-config.png">
+Additionally if you have configured your Kiuwan account to use SSO authentication you have to configure your Kiuwan Domain ID provided by your Kiuwan administrator.
+
+<img src="https://www.kiuwan.com/wp-content/uploads/2019/06/kiuwan-endpoint-config.png">
 
 ### **NOTE**: Kiuwan credentials for your build tasks
 You can now configure the Kiuwan connection in your existing tasks. The credentials configured the selected Kiuwan connection will be used to run the analysis. For backward compatibility, if you don't configure the Kiuwan connection in the task, the build definition variables: KiuwanUser and KiuwanPasswd, will be use for credentials. These variables can be used as well to override the Kiuwan connection credentials. This can be useful if you want a particular build definition to run analyses with a different user.

--- a/vss-extension-dev.json
+++ b/vss-extension-dev.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "kiuwan-analysis-extension-dev",
     "name": "Kiuwan Dev",
-    "version": "2.3.92",
+    "version": "2.3.94",
     "publisher": "kiuwan-publisher",
     "targets": [
         {
@@ -187,8 +187,23 @@
                 "displayName": "Kiuwan Platform",
                 "url": {
                     "displayName": "Kiuwan URL",
-                    "helpText": "For the cloud Kiuwan Service use: https://www.kiuwan.com This is the default.</br>For Kiuwan Enterprise on-premises use your Kiuwan server URL (i.e. http://kiuwan.mycompany.com)."
+                    "helpText": "For the cloud Kiuwan Service use: https://www.kiuwan.com This is the default.</br>For Kiuwan Enterprise on-premises use your Kiuwan server URL (i.e. http://kiuwan.mycompany.com).",
+                    "isVisible": true
                 },
+                "inputDescriptors": [
+                    {
+                        "id": "domainid",
+                        "name": "Kiuwan Domain ID",
+                        "description": "If your Kiuwan account is configured for SSO authentication, set here the Domain ID for your account. Contact your Kiuwan admin for details.<br />Leave empty otherwise.<br /><b>WARNING</b>: for TFS 2005 set this to 0 (the number zero) for non-SSO Kiuwan accounts. In this case the combo with possible applications in the tasks definitions will not work. This is a shortcoming of TFS 2005 only",
+                        "inputMode": "textbox",
+                        "isConfidential": false,
+                        "validation": {
+                            "isRequired": false,
+                            "dataType": "string",
+                            "maxLength": 255
+                        }
+                    }
+                ],
                 "dataSources": [
                     {
                         "name": "TestConnection",
@@ -204,6 +219,12 @@
                 "authenticationSchemes": [
                     {
                         "type": "ms.vss-endpoint.endpoint-auth-scheme-basic",
+                        "headers": [
+                            {
+                                "name": "X-KW-CORPORATE-DOMAIN-ID",
+                                "value": "{{endpoint.domainid}}"
+                            }
+                        ],
                         "inputDescriptors": [
                             {
                                 "id": "username",
@@ -212,7 +233,7 @@
                                 "inputMode": "textbox",
                                 "isConfidential": false,
                                 "validation": {
-                                    "isrequired": true,
+                                    "isRequired": true,
                                     "dataType": "string"
                                 }
                             },
@@ -223,7 +244,7 @@
                                 "inputMode": "passwordBox",
                                 "isConfidential": true,
                                 "validation": {
-                                    "isrequired": true,
+                                    "isRequired": true,
                                     "dataType": "string"
                                 }
                             }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "kiuwan-analysis-extension",
     "name": "Kiuwan",
-    "version": "2.3.18",
+    "version": "2.3.34",
     "publisher": "kiuwan-publisher",
     "targets": [
         {
@@ -105,7 +105,7 @@
             "path": "node_modules/vss-web-extension-sdk/lib",
             "addressable": true,
             "packagePath": "lib"
-        }        
+        }
     ],
     "contributions": [
         {
@@ -117,8 +117,10 @@
             ],
             "properties": {
                 "name": "Kiuwan",
-                 "uri": "kiuwanTab.html",
-                 "supportsTasks": ["f345ac07-f8a0-4859-bcaf-d71fd62bcf37"]
+                "uri": "kiuwanTab.html",
+                "supportsTasks": [
+                    "f345ac07-f8a0-4859-bcaf-d71fd62bcf37"
+                ]
             }
         },
         {
@@ -129,14 +131,14 @@
                 "ms.vss-build-web.build-results-summary-tab"
             ],
             "properties": {
-                 "name": "Kiuwan Summary",
-                 "uri": "kiuwanSummary.html",
-                 "supportsTasks": [
+                "name": "Kiuwan Summary",
+                "uri": "kiuwanSummary.html",
+                "supportsTasks": [
                     "f345ac07-f8a0-4859-bcaf-d71fd62bcf37",
                     "4e6e25e3-c0b5-4986-8714-5c751945c15f"
-                   ],
+                ],
                 "order": 20,
-                 "height": 300
+                "height": 300
             }
         },
         {
@@ -148,8 +150,10 @@
             ],
             "properties": {
                 "name": "Kiuwan Audit",
-                 "uri": "kiuwanAuditTab.html",
-                 "supportsTasks": ["4e6e25e3-c0b5-4986-8714-5c751945c15f"]
+                "uri": "kiuwanAuditTab.html",
+                "supportsTasks": [
+                    "4e6e25e3-c0b5-4986-8714-5c751945c15f"
+                ]
             }
         },
         {
@@ -187,6 +191,20 @@
                     "helpText": "For the cloud Kiuwan Service use: https://www.kiuwan.com This is the default.</br>For Kiuwan Enterprise on-premises use your Kiuwan server URL (i.e. http://kiuwan.mycompany.com).",
                     "isVisible": true
                 },
+                "inputDescriptors": [
+                    {
+                        "id": "domainid",
+                        "name": "Kiuwan Domain ID",
+                        "description": "If your Kiuwan account is configured for SSO authentication, set here the Domain ID for your account. Contact your Kiuwan admin for details.<br />Leave empty otherwise.<br /><b>WARNING</b>: for TFS 2005 set this to 0 (the number zero) for non-SSO Kiuwan accounts. In this case the combo with possible applications in the tasks definitions will not work. This is a shortcoming of TFS 2005 only",
+                        "inputMode": "textbox",
+                        "isConfidential": false,
+                        "validation": {
+                            "isRequired": false,
+                            "dataType": "string",
+                            "maxLength": 255
+                        }
+                    }
+                ],
                 "dataSources": [
                     {
                         "name": "TestConnection",
@@ -202,6 +220,12 @@
                 "authenticationSchemes": [
                     {
                         "type": "ms.vss-endpoint.endpoint-auth-scheme-basic",
+                        "headers": [
+                            {
+                                "name": "X-KW-CORPORATE-DOMAIN-ID",
+                                "value": "{{endpoint.domainid}}"
+                            }
+                        ],
                         "inputDescriptors": [
                             {
                                 "id": "username",
@@ -210,7 +234,7 @@
                                 "inputMode": "textbox",
                                 "isConfidential": false,
                                 "validation": {
-                                    "isrequired": true,
+                                    "isRequired": true,
                                     "dataType": "string"
                                 }
                             },
@@ -221,7 +245,7 @@
                                 "inputMode": "passwordBox",
                                 "isConfidential": true,
                                 "validation": {
-                                    "isrequired": true,
+                                    "isRequired": true,
                                     "dataType": "string"
                                 }
                             }


### PR DESCRIPTION
For those Kiuwan accounts that have configured SSO there is a new parameter that needs to be configured in the connection to Kiuwan, the Domain ID.
This new version adds and uses that parameter when it is used.
One caveat for TFS 2015. The interface doesn't allow to leave that new field empty when there is no SSO. In that case, and only in that case it has to be set to 0. This has the side effect that the combo with the applications is not filled  in the tasks definitions.