### PR TITLE
KWN-4116: Updating overview.md documentation link to latest support.kiuwan.com docs site.

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -6,7 +6,7 @@ You can also define a Kiuwan service endpoint. This will allow you to store your
 
 Because this extension works with the Kiuwan Application Security platform, you need a Kiuwan account in our cloud service or an on-premise installation of the Kiuwan platform to use it.
 
-Read more detailed information in our tech doc page: [Microsoft TFS Azure DevOps Extension](https://kiuwan.zendesk.com/hc/en-us/articles/18098151626396-Microsoft-TFS-Azure-DevOps-Extension)
+Read more detailed information in our tech doc page: [Microsoft TFS Azure DevOps Extension](https://support.kiuwan.com/hc/en-us/articles/36335481452817-Microsoft-TFS-Azure-DevOps-Extension)
 
 ## What you get with the extension ##
 


### PR DESCRIPTION
KWN-4116: Changing overview.md file to point to support.kiuwan.com docs instead of kiuwan.zendesk.com docs.